### PR TITLE
Rk/add surge cname file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@
 /coverage
 
 # production
-/build
+/build*
+!/build/CNAME
 
 # misc
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /coverage
 
 # production
-/build*
+/build/*
 !/build/CNAME
 
 # misc

--- a/build/CNAME
+++ b/build/CNAME
@@ -1,0 +1,1 @@
+bookguesser.surge.sh


### PR DESCRIPTION
I don't want to keep typing the surge.sh subdomain each time I deploy.